### PR TITLE
fix: experimental appDir

### DIFF
--- a/next/next.config.js
+++ b/next/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  experimental:{appDir: true}
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
run `npm run dev` in next

Error: > The `app` dir is experimental. Please add `{experimental:{appDir: true}}` to your `next.config.js` to enable it


